### PR TITLE
changing a -> A

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -83,7 +83,7 @@ bindkey "^B" backward-char
 #allow backspace to clear newline.
 bindkey '^?' backward-delete-char
 #bindkey "^F" forward-char
-bindkey "^a" beginning-of-line
+bindkey "^A" beginning-of-line
 bindkey "^e" end-of-line
 bindkey "^[[1;5C" forward-word
 bindkey "^[[1;5D" backward-word


### PR DESCRIPTION
Sorry for mentioning this late, but I was using your blazingly fast, ultra-sonic, epicuh zsh config. However I was not able to go to the front of my line every time I forgot using 'sudo', that's when I realized that in your config, (ultra-fast super-sonic, epicuh config) the bind for go-to-beginning of line was for ^a and not for ^A. I believe this might be a subjective change, but I just wanted to make a PR on your ultra super sonic, fast as f*ck config.

Bye